### PR TITLE
Added time for restoredate parameter

### DIFF
--- a/push_restore_readme.md
+++ b/push_restore_readme.md
@@ -34,7 +34,7 @@ TargetDirectory
 
 RestoreDate
 - **Mandatory:** False
-- Date to restore files from. If not provided today's date will be used. In a yyyy-MM-dd format forexample: 2025-12-31
+- Date to restore files from. If not provided today's date will be used. Can be any format Powershell recognizes. For example: 2025-12-31, 2025-12-31 1:37PM, 2025-12-31 13:37
 
 RestoreDeletedFiles
 - **Mandatory:** False


### PR DESCRIPTION
Modified RestoreDate parameter to accept any DateTime value PowerShell recognizes.
Fixed a bug in Windows where not providing an InputPath threw an error.
Fixed a typo.